### PR TITLE
Yeni  siteler ve kategoriler eklendi  siteler iktidara yakın medya ve şirketler olarak boykot listesinde yer almaktadır

### DIFF
--- a/turkiye_hukumet_medya_engel_listesi.txt
+++ b/turkiye_hukumet_medya_engel_listesi.txt
@@ -26,6 +26,7 @@
 ||ahaber.com.tr^
 ||ntv.com.tr^
 ||cnnturk.com^
+||tgrthaber.com^
 ||tgrthaber.com.tr^
 ||beyaztv.com.tr^
 ||ulketv.com^
@@ -48,6 +49,7 @@
 ||dirilispostasi.com^
 ||vogue.com.tr^
 ||gq.com.tr^
+||turkuvazkitap.com.tr^
 
 ! Radyo Kanalları
 ||trt.net.tr^
@@ -72,3 +74,21 @@
 ||beinsports.com.tr^  
 ||bloomberght.com^ 
 ||puhutv.com^
+
+! Medya Holding Şirketleri
+||ihlasyayinholding.com.tr^
+
+! E-Ticaret Platformları
+||idefix.com^
+||dr.com.tr^
+||etstur.com^
+
+! Bahis, Şans Oyunları ve Piyango Siteleri
+||misli.com^
+||millipiyangoonline.com^
+
+! Mobilya ve Dekorasyon Şirketleri
+||kilimmobilya.com.tr^
+
+! Gıda ve Kahve Zincirleri
+||espressolab.com^


### PR DESCRIPTION
Bu güncelleme kapsamında listeye hükümet yanlısı olduğu bilinen yeni siteler eklenmiştir. 

Eklenen siteler:
- turkuvazkitap.com.tr (Turkuvaz Kitap - Hükümet yanlısı medya grubunun yayınevi)
- misli.com (Hükümet yanlısı iş insanları tarafından işletilen bahis sitesi)
- millipiyangoonline.com (Turkuvaz grubu işletmesindeki şans oyunları platformu)
- kilimmobilya.com.tr (Hükümet ile yakın ilişkileri bilinen mobilya şirketi)

Ayrıca listedeki sitelerin daha iyi organize edilmesi için yeni kategoriler oluşturulmuştur:
- Bahis, Şans Oyunları ve Piyango Siteleri
- Mobilya ve Dekorasyon Şirketleri

